### PR TITLE
Fix Windows Ollama startup

### DIFF
--- a/src/utils/ollama.py
+++ b/src/utils/ollama.py
@@ -70,10 +70,8 @@ def start_ollama_server() -> bool:
     system = platform.system().lower()
 
     try:
-        if system == "darwin" or system == "linux":  # macOS or Linux
+        if system in ("darwin", "linux", "windows"):
             subprocess.Popen(["ollama", "serve"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        elif system == "windows":  # Windows
-            subprocess.Popen(["ollama", "serve"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         else:
             print(f"{Fore.RED}Unsupported operating system: {system}{Style.RESET_ALL}")
             return False


### PR DESCRIPTION
## Summary
- remove `shell=True` when starting `ollama serve`
- keep `shell=True` usage for `where` check on Windows

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb8e55900832682c236bfd0a0858f