### PR TITLE
Add tests for helper functions

### DIFF
--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -10,12 +10,9 @@ from app.backend.models.events import (
     StartEvent,
 )
 from app.backend.models.schemas import ErrorResponse, HedgeFundRequest
-from app.backend.services.graph import (
-    create_graph,
-    parse_hedge_fund_response,
-    run_graph_async,
-)
+from app.backend.services.graph import create_graph, run_graph_async
 from app.backend.services.portfolio import create_portfolio
+from src.utils.parsing import parse_hedge_fund_response
 from src.utils.progress import progress
 
 router = APIRouter(prefix="/hedge-fund")

--- a/app/backend/services/graph.py
+++ b/app/backend/services/graph.py
@@ -9,6 +9,7 @@ from src.agents.risk_manager import risk_management_agent
 from src.graph.state import AgentState
 from src.main import start
 from src.utils.analysts import ANALYST_CONFIG
+from src.utils.parsing import parse_hedge_fund_response
 
 
 # Helper function to create the agent graph
@@ -98,18 +99,3 @@ def run_graph(
             },
         },
     )
-
-
-def parse_hedge_fund_response(response):
-    """Parses a JSON string and returns a dictionary."""
-    try:
-        return json.loads(response)
-    except json.JSONDecodeError as e:
-        print(f"JSON decoding error: {e}\nResponse: {repr(response)}")
-        return None
-    except TypeError as e:
-        print(f"Invalid response type (expected string, got {type(response).__name__}): {e}")
-        return None
-    except Exception as e:
-        print(f"Unexpected error while parsing response: {e}\nResponse: {repr(response)}")
-        return None

--- a/src/main.py
+++ b/src/main.py
@@ -1,44 +1,30 @@
+import argparse
+import json
 import sys
+from datetime import datetime
 
+import questionary
+from colorama import Fore, init, Style
+from dateutil.relativedelta import relativedelta
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage
 from langgraph.graph import END, StateGraph
-from colorama import Fore, Style, init
-import questionary
+
 from src.agents.portfolio_manager import portfolio_management_agent
 from src.agents.risk_manager import risk_management_agent
 from src.graph.state import AgentState
-from src.utils.display import print_trading_output
+from src.llm.models import get_model_info, LLM_ORDER, ModelProvider, OLLAMA_LLM_ORDER
 from src.utils.analysts import ANALYST_ORDER, get_analyst_nodes
-from src.utils.progress import progress
-from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider
+from src.utils.display import print_trading_output
 from src.utils.ollama import ensure_ollama_and_model
-
-import argparse
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
+from src.utils.parsing import parse_hedge_fund_response
+from src.utils.progress import progress
 from src.utils.visualize import save_graph_as_png
-import json
 
 # Load environment variables from .env file
 load_dotenv()
 
 init(autoreset=True)
-
-
-def parse_hedge_fund_response(response):
-    """Parses a JSON string and returns a dictionary."""
-    try:
-        return json.loads(response)
-    except json.JSONDecodeError as e:
-        print(f"JSON decoding error: {e}\nResponse: {repr(response)}")
-        return None
-    except TypeError as e:
-        print(f"Invalid response type (expected string, got {type(response).__name__}): {e}")
-        return None
-    except Exception as e:
-        print(f"Unexpected error while parsing response: {e}\nResponse: {repr(response)}")
-        return None
 
 
 ##### Run the Hedge Fund #####

--- a/src/utils/parsing.py
+++ b/src/utils/parsing.py
@@ -1,0 +1,16 @@
+import json
+
+
+def parse_hedge_fund_response(response):
+    """Parses a JSON string and returns a dictionary."""
+    try:
+        return json.loads(response)
+    except json.JSONDecodeError as e:
+        print(f"JSON decoding error: {e}\nResponse: {repr(response)}")
+        return None
+    except TypeError as e:
+        print(f"Invalid response type (expected string, got {type(response).__name__}): {e}")
+        return None
+    except Exception as e:
+        print(f"Unexpected error while parsing response: {e}\nResponse: {repr(response)}")
+        return None

--- a/tests/test_crypto_pipeline.py
+++ b/tests/test_crypto_pipeline.py
@@ -1,12 +1,91 @@
+import importlib
 import os
 import sys
+import types
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import pytest
 
-pytest.importorskip("langchain_core", reason="langchain not installed")
-from app.backend.services.graph import run_graph
+
+@pytest.fixture
+def graph_module(monkeypatch):
+    """Load graph module with mocked langchain dependencies."""
+    # Mock langchain_core.messages.HumanMessage
+    lc_messages = types.ModuleType("langchain_core.messages")
+
+    class DummyMessage:
+        def __init__(self, content=None):
+            self.content = content
+
+    lc_messages.HumanMessage = DummyMessage
+    monkeypatch.setitem(sys.modules, "langchain_core.messages", lc_messages)
+    lc_core = types.ModuleType("langchain_core")
+    lc_core.messages = lc_messages
+    monkeypatch.setitem(sys.modules, "langchain_core", lc_core)
+
+    # Mock langgraph.graph.StateGraph and END
+    lg_graph = types.ModuleType("langgraph.graph")
+
+    class DummyGraph:
+        def __init__(self, *args, **kwargs):
+            self.called_with = None
+
+        def add_node(self, *a, **k):
+            pass
+
+        def add_edge(self, *a, **k):
+            pass
+
+        def set_entry_point(self, *a, **k):
+            pass
+
+        def compile(self):
+            return self
+
+        def invoke(self, data):
+            self.called_with = data
+            return {"result": True}
+
+    lg_graph.StateGraph = DummyGraph
+    lg_graph.END = object()
+    lg = types.ModuleType("langgraph")
+    lg.graph = lg_graph
+    monkeypatch.setitem(sys.modules, "langgraph.graph", lg_graph)
+    monkeypatch.setitem(sys.modules, "langgraph", lg)
+
+    # Stub other imports used by the module
+    dummy_mods = {
+        "src.agents.portfolio_manager": types.ModuleType("src.agents.portfolio_manager"),
+        "src.agents.risk_manager": types.ModuleType("src.agents.risk_manager"),
+        "src.graph.state": types.ModuleType("src.graph.state"),
+        "src.main": types.ModuleType("src.main"),
+        "src.utils.analysts": types.ModuleType("src.utils.analysts"),
+    }
+    dummy_mods["src.agents.portfolio_manager"].portfolio_management_agent = lambda x: x
+    dummy_mods["src.agents.risk_manager"].risk_management_agent = lambda x: x
+    dummy_mods["src.graph.state"].AgentState = object
+    dummy_mods["src.main"].start = lambda x: x
+    dummy_mods["src.utils.analysts"].ANALYST_CONFIG = {}
+
+    for name, mod in dummy_mods.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    return importlib.import_module("app.backend.services.graph")
 
 
-def test_crypto_smoke():
-    run_graph(pair="BTC/USDT", exchange="binance", timeframe="1h")
+def test_run_graph_invocation(graph_module):
+    graph = graph_module.StateGraph()
+    result = graph_module.run_graph(
+        graph=graph,
+        portfolio={"cash": 1000},
+        tickers=["BTC/USDT"],
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+        model_name="gpt",
+        model_provider="OpenAI",
+        exchange="binance",
+    )
+
+    assert result == {"result": True}
+    assert graph.called_with["data"]["tickers"] == ["BTC/USDT"]

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,49 @@
+import importlib
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+
+from src.utils.parsing import parse_hedge_fund_response
+
+
+@pytest.fixture
+def llm_module(monkeypatch):
+    """Import src.utils.llm with mocked dependencies."""
+    dummy_models = types.ModuleType("src.llm.models")
+    dummy_models.get_model = lambda *a, **k: None
+    dummy_models.get_model_info = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "src.llm.models", dummy_models)
+
+    dummy_progress = types.ModuleType("src.utils.progress")
+    dummy_progress.progress = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "src.utils.progress", dummy_progress)
+
+    return importlib.import_module("src.utils.llm")
+
+
+def test_parse_valid_json():
+    assert parse_hedge_fund_response('{"a": 1}') == {"a": 1}
+
+
+def test_parse_invalid_json():
+    assert parse_hedge_fund_response('{"a": 1') is None
+
+
+def test_parse_wrong_type():
+    assert parse_hedge_fund_response(None) is None
+
+
+def test_extract_json_success(llm_module):
+    content = 'some text ```json {\n  "b": 2\n} ``` end'
+    assert llm_module.extract_json_from_response(content) == {"b": 2}
+
+
+def test_extract_json_no_block(llm_module):
+    assert llm_module.extract_json_from_response("no json here") is None
+
+
+def test_extract_json_invalid_json(llm_module):
+    assert llm_module.extract_json_from_response("```json {bad} ```") is None


### PR DESCRIPTION
## Summary
- extract `parse_hedge_fund_response` helper into `src/utils/parsing.py`
- update imports to use the new helper location
- mock external `langchain` dependencies in tests
- add unit tests for parsing helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb8e32a948326a67251d4474f9683