### PR TITLE
Fix portfolio formatting

### DIFF
--- a/app/backend/services/portfolio.py
+++ b/app/backend/services/portfolio.py
@@ -1,7 +1,6 @@
 
-
 def create_portfolio(initial_cash: float, margin_requirement: float, tickers: list[str]) -> dict:
-  return {
+    return {
         "cash": initial_cash,  # Initial cash amount
         "margin_requirement": margin_requirement,  # Initial margin requirement
         "margin_used": 0.0,  # total margin usage across all short positions


### PR DESCRIPTION
## Summary
- use four-space indentation for the portfolio service
- add a leading blank line to satisfy style tools
- format with `isort` and `black`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb8e169c08326860d818adf4dacab