### PR TITLE
Centralize parse helper

### DIFF
--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -10,11 +10,8 @@ from app.backend.models.events import (
     StartEvent,
 )
 from app.backend.models.schemas import ErrorResponse, HedgeFundRequest
-from app.backend.services.graph import (
-    create_graph,
-    parse_hedge_fund_response,
-    run_graph_async,
-)
+from app.backend.services.graph import create_graph, run_graph_async
+from src.utils.parsing import parse_hedge_fund_response
 from app.backend.services.portfolio import create_portfolio
 from src.utils.progress import progress
 

--- a/app/backend/services/graph.py
+++ b/app/backend/services/graph.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 
+from src.utils.parsing import parse_hedge_fund_response
+
 from langchain_core.messages import HumanMessage
 from langgraph.graph import END, StateGraph
 
@@ -98,18 +100,3 @@ def run_graph(
             },
         },
     )
-
-
-def parse_hedge_fund_response(response):
-    """Parses a JSON string and returns a dictionary."""
-    try:
-        return json.loads(response)
-    except json.JSONDecodeError as e:
-        print(f"JSON decoding error: {e}\nResponse: {repr(response)}")
-        return None
-    except TypeError as e:
-        print(f"Invalid response type (expected string, got {type(response).__name__}): {e}")
-        return None
-    except Exception as e:
-        print(f"Unexpected error while parsing response: {e}\nResponse: {repr(response)}")
-        return None

--- a/src/main.py
+++ b/src/main.py
@@ -18,27 +18,13 @@ import argparse
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from src.utils.visualize import save_graph_as_png
+from src.utils.parsing import parse_hedge_fund_response
 import json
 
 # Load environment variables from .env file
 load_dotenv()
 
 init(autoreset=True)
-
-
-def parse_hedge_fund_response(response):
-    """Parses a JSON string and returns a dictionary."""
-    try:
-        return json.loads(response)
-    except json.JSONDecodeError as e:
-        print(f"JSON decoding error: {e}\nResponse: {repr(response)}")
-        return None
-    except TypeError as e:
-        print(f"Invalid response type (expected string, got {type(response).__name__}): {e}")
-        return None
-    except Exception as e:
-        print(f"Unexpected error while parsing response: {e}\nResponse: {repr(response)}")
-        return None
 
 
 ##### Run the Hedge Fund #####

--- a/src/utils/parsing.py
+++ b/src/utils/parsing.py
@@ -1,0 +1,29 @@
+"""Utility functions for parsing model responses."""
+import json
+from typing import Any, Optional
+
+
+def parse_hedge_fund_response(response: str) -> Optional[dict[str, Any]]:
+    """Parse a hedge fund JSON response safely.
+
+    Args:
+        response: The raw JSON string returned by the agent.
+
+    Returns:
+        A dictionary representation of the JSON response or ``None`` if parsing
+        fails.
+    """
+    try:
+        return json.loads(response)
+    except json.JSONDecodeError as e:
+        print(f"JSON decoding error: {e}\nResponse: {repr(response)}")
+        return None
+    except TypeError as e:
+        print(
+            f"Invalid response type (expected string, got {type(response).__name__}): {e}"
+        )
+        return None
+    except Exception as e:  # noqa: BLE001
+        print(f"Unexpected error while parsing response: {e}\nResponse: {repr(response)}")
+        return None
+


### PR DESCRIPTION
## Summary
- add `src/utils/parsing.py` with `parse_hedge_fund_response`
- update imports to use the shared parser
- remove duplicated parsing logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb8e01dcc8326a35156a3238ac3cd